### PR TITLE
Add CI workflow with tests, lint, pip-audit, gitleaks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Lint with ruff
+        run: |
+          ruff check .
+          ruff format --check .
+
+      - name: Run tests
+        run: |
+          python -m pytest tests/ -v --tb=short
+
+      - name: Run pip-audit
+        run: |
+          pip install pip-audit
+          pip-audit --desc
+
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Run gitleaks
         uses: gitleaks/gitleaks-action@v2


### PR DESCRIPTION
## Summary
- Create complete GitHub Actions CI pipeline
- Includes: Python 3.12, ruff lint/format, pytest, pip-audit vulnerability scanning, gitleaks secret scanning
- Previously had no CI workflow at all

## Context
Part of cross-repo security audit (2026-03-07). Adds both CI testing and security scanning that were missing.

## Test plan
- [ ] CI pipeline runs green on this PR
- [ ] gitleaks detects no secrets
- [ ] pip-audit reports zero known vulnerabilities
- [ ] Tests pass in CI

Generated with Claude Code