### PR TITLE
fix: respect .gitignore when scanning codebases

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 MCP server + CLI that reverse-engineers institutional knowledge from codebases.
-Deep research project: `~/deep-research/active/codebase-archaeologist/BRIEF.md`
+Deep research project: `~/build-logs/deep-research/active/codebase-archaeologist/BRIEF.md`
 
 ## Stack
 - Python 3.12+

--- a/src/codebase_archaeologist/analyzers/base.py
+++ b/src/codebase_archaeologist/analyzers/base.py
@@ -49,15 +49,15 @@ class BaseAnalyzer(ABC):
         self._git_checked = True
         try:
             result = subprocess.run(
-                ["git", "ls-files", "--cached", "--others", "--exclude-standard"],
+                ["git", "ls-files", "--cached", "--others", "--exclude-standard", "-z"],
                 capture_output=True,
                 text=True,
                 cwd=self.repo_path,
                 timeout=30,
             )
-            if result.returncode == 0 and result.stdout.strip():
+            if result.returncode == 0 and result.stdout.strip("\0"):
                 self._git_files = {
-                    self.repo_path / line for line in result.stdout.strip().split("\n") if line
+                    self.repo_path / entry for entry in result.stdout.split("\0") if entry
                 }
         except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
             pass

--- a/src/codebase_archaeologist/analyzers/base.py
+++ b/src/codebase_archaeologist/analyzers/base.py
@@ -1,9 +1,28 @@
 """Base class for all analyzers."""
 
+from __future__ import annotations
+
+import subprocess
 from abc import ABC, abstractmethod
 from pathlib import Path
 
 MAX_FILE_SIZE = 1_000_000  # 1 MB — skip files larger than this
+
+_FALLBACK_EXCLUDE_DIRS = frozenset(
+    {
+        ".git",
+        "__pycache__",
+        "node_modules",
+        ".venv",
+        "venv",
+        ".tox",
+        ".eggs",
+        "dist",
+        "build",
+        ".mypy_cache",
+        ".ruff_cache",
+    }
+)
 
 
 class BaseAnalyzer(ABC):
@@ -12,37 +31,103 @@ class BaseAnalyzer(ABC):
     def __init__(self, repo_path: Path, max_files: int = 500):
         self.repo_path = repo_path
         self.max_files = max_files
+        self._git_files: set[Path] | None = None
+        self._git_checked = False
 
     @abstractmethod
     def analyze(self):
         """Run analysis and return a result dataclass."""
 
+    def _get_git_files(self) -> set[Path] | None:
+        """Get the set of git-relevant files (tracked + untracked non-ignored).
+
+        Returns None if the repo is not a git repo or git is unavailable.
+        Result is cached for the lifetime of the analyzer instance.
+        """
+        if self._git_checked:
+            return self._git_files
+        self._git_checked = True
+        try:
+            result = subprocess.run(
+                ["git", "ls-files", "--cached", "--others", "--exclude-standard"],
+                capture_output=True,
+                text=True,
+                cwd=self.repo_path,
+                timeout=30,
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                self._git_files = {
+                    self.repo_path / line for line in result.stdout.strip().split("\n") if line
+                }
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+            pass
+        return self._git_files
+
+    def _is_path_gitignored(self, path: Path) -> bool:
+        """Check if a path would be excluded by git.
+
+        If git info is unavailable, falls back to hardcoded exclude dirs.
+        """
+        git_files = self._get_git_files()
+        if git_files is not None:
+            if path.is_file():
+                return path not in git_files
+            # For directories: check if any git file lives under this dir
+            return not any(f.is_relative_to(path) for f in git_files)
+        return any(d in path.parts for d in _FALLBACK_EXCLUDE_DIRS)
+
     def _collect_files(
-        self, extensions: set[str] | None = None, exclude_dirs: set[str] | None = None
+        self,
+        extensions: set[str] | None = None,
+        exclude_dirs: set[str] | None = None,
     ) -> list[Path]:
-        """Collect files from repo, respecting max_files limit."""
-        if exclude_dirs is None:
-            exclude_dirs = {
-                ".git",
-                "__pycache__",
-                "node_modules",
-                ".venv",
-                "venv",
-                ".tox",
-                ".eggs",
-                "dist",
-                "build",
-                ".mypy_cache",
-                ".ruff_cache",
-            }
+        """Collect files from repo, respecting .gitignore and max_files limit."""
         resolved_root = self.repo_path.resolve()
+        git_files = self._get_git_files()
+
+        if git_files is not None:
+            return self._collect_from_git(git_files, extensions, resolved_root)
+        return self._collect_from_rglob(
+            extensions, exclude_dirs or _FALLBACK_EXCLUDE_DIRS, resolved_root
+        )
+
+    def _collect_from_git(
+        self,
+        git_files: set[Path],
+        extensions: set[str] | None,
+        resolved_root: Path,
+    ) -> list[Path]:
+        """Collect files using git ls-files as the source of truth."""
+        files = []
+        for f in sorted(git_files):
+            if f.is_symlink():
+                continue
+            if not f.is_file():
+                continue
+            try:
+                f.resolve().relative_to(resolved_root)
+            except ValueError:
+                continue
+            if extensions is not None and f.suffix not in extensions:
+                continue
+            files.append(f)
+            if len(files) >= self.max_files:
+                break
+        return files
+
+    def _collect_from_rglob(
+        self,
+        extensions: set[str] | None,
+        exclude_dirs: frozenset[str] | set[str],
+        resolved_root: Path,
+    ) -> list[Path]:
+        """Fallback: collect files via rglob with hardcoded exclude dirs."""
         files = []
         for f in self.repo_path.rglob("*"):
             if f.is_symlink():
                 continue
             if not f.is_file():
                 continue
-            # Verify file is within repo (prevent symlink escapes)
             try:
                 f.resolve().relative_to(resolved_root)
             except ValueError:

--- a/src/codebase_archaeologist/analyzers/code_structure.py
+++ b/src/codebase_archaeologist/analyzers/code_structure.py
@@ -225,38 +225,27 @@ class CodeStructureAnalyzer(BaseAnalyzer):
                         )
 
     def _build_directory_tree(self) -> dict[str, list[str]]:
-        """Build a directory tree representation (top 2 levels)."""
-        exclude_dirs = {
-            ".git",
-            "__pycache__",
-            "node_modules",
-            ".venv",
-            "venv",
-            ".tox",
-            ".eggs",
-            "dist",
-            "build",
-            ".mypy_cache",
-            ".ruff_cache",
-        }
+        """Build a directory tree representation (top 2 levels), respecting .gitignore."""
         tree: dict[str, list[str]] = {}
 
         # Level 0: repo root
         root_entries: list[str] = []
         for item in sorted(self.repo_path.iterdir()):
-            if item.name in exclude_dirs:
+            if self._is_path_gitignored(item):
                 continue
             root_entries.append(item.name + ("/" if item.is_dir() else ""))
         tree["."] = root_entries
 
         # Level 1: immediate subdirectories
         for item in sorted(self.repo_path.iterdir()):
-            if not item.is_dir() or item.name in exclude_dirs or item.name.startswith("."):
+            if not item.is_dir() or item.name.startswith("."):
+                continue
+            if self._is_path_gitignored(item):
                 continue
             sub_entries: list[str] = []
             try:
                 for child in sorted(item.iterdir()):
-                    if child.name in exclude_dirs:
+                    if self._is_path_gitignored(child):
                         continue
                     sub_entries.append(child.name + ("/" if child.is_dir() else ""))
             except PermissionError:

--- a/src/codebase_archaeologist/analyzers/code_structure.py
+++ b/src/codebase_archaeologist/analyzers/code_structure.py
@@ -238,7 +238,7 @@ class CodeStructureAnalyzer(BaseAnalyzer):
 
         # Level 1: immediate subdirectories
         for item in sorted(self.repo_path.iterdir()):
-            if not item.is_dir() or item.name.startswith("."):
+            if not item.is_dir():
                 continue
             if self._is_path_gitignored(item):
                 continue

--- a/src/codebase_archaeologist/analyzers/pattern_detector.py
+++ b/src/codebase_archaeologist/analyzers/pattern_detector.py
@@ -196,11 +196,13 @@ class PatternDetector(BaseAnalyzer):
         """Detect architecture patterns based on directory structure."""
         patterns: list[str] = []
 
-        # Collect top-level and nested directory names
+        # Derive directory names from collected (git-aware) files
+        all_files = self._collect_files()
         dir_names: set[str] = set()
-        for path in self.repo_path.rglob("*"):
-            if path.is_dir():
-                dir_names.add(path.name)
+        for f in all_files:
+            for parent in f.relative_to(self.repo_path).parents:
+                if parent.name:
+                    dir_names.add(parent.name)
 
         # Layered architecture
         if dir_names & _LAYERED_DIRS:
@@ -218,9 +220,9 @@ class PatternDetector(BaseAnalyzer):
         if (self.repo_path / "src").is_dir():
             patterns.append("src-layout")
 
-        # Monorepo: multiple pyproject.toml or package.json
-        pyproject_count = len(list(self.repo_path.rglob("pyproject.toml")))
-        package_json_count = len(list(self.repo_path.rglob("package.json")))
+        # Monorepo: multiple pyproject.toml or package.json in non-ignored dirs
+        pyproject_count = sum(1 for f in all_files if f.name == "pyproject.toml")
+        package_json_count = sum(1 for f in all_files if f.name == "package.json")
         if pyproject_count > 1 or package_json_count > 1:
             patterns.append("monorepo")
 

--- a/tests/analyzers/test_code_structure.py
+++ b/tests/analyzers/test_code_structure.py
@@ -67,3 +67,47 @@ class TestCodeStructureAnalyzer:
         assert result.has_ci is False
         assert result.config_files == []
         assert result.entry_points == []
+
+    def test_gitignored_files_excluded(self, tmp_repo: Path) -> None:
+        """Files in gitignored directories should not appear in analysis."""
+        # Create a venv-like directory with Python files
+        venv = tmp_repo / ".venv-custom"
+        venv.mkdir()
+        pkg = venv / "lib" / "site-packages" / "somepkg"
+        pkg.mkdir(parents=True)
+        (pkg / "cli.py").write_text("def main():\n    pass\n")
+        (pkg / "app.py").write_text("def run():\n    pass\n")
+
+        # Add to .gitignore
+        (tmp_repo / ".gitignore").write_text(".venv-custom/\n")
+        subprocess.run(["git", "add", ".gitignore"], cwd=tmp_repo, capture_output=True, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "chore: add gitignore"],
+            cwd=tmp_repo,
+            capture_output=True,
+            check=True,
+        )
+
+        analyzer = CodeStructureAnalyzer(tmp_repo)
+        result = analyzer.analyze()
+
+        # Entry points should NOT include files from .venv-custom
+        entry_paths = [ep.path for ep in result.entry_points]
+        for path in entry_paths:
+            assert ".venv-custom" not in path, f"Gitignored file leaked: {path}"
+
+        # Directory tree should NOT include .venv-custom
+        root_items = result.directory_tree.get(".", [])
+        assert ".venv-custom/" not in root_items
+
+    def test_untracked_non_ignored_files_included(self, tmp_repo: Path) -> None:
+        """New files not yet staged should still appear (they're not gitignored)."""
+        # Create a new file without staging it
+        (tmp_repo / "src" / "myproject" / "new_module.py").write_text(
+            "def new_function():\n    pass\n"
+        )
+
+        analyzer = CodeStructureAnalyzer(tmp_repo)
+        all_files = analyzer._collect_files(extensions={".py"})
+        file_names = [f.name for f in all_files]
+        assert "new_module.py" in file_names

--- a/tests/analyzers/test_pattern_detector.py
+++ b/tests/analyzers/test_pattern_detector.py
@@ -85,3 +85,56 @@ class TestPatternDetector:
         assert result.test_patterns == []
         assert result.type_hint_ratio == 0.0
         assert result.docstring_ratio == 0.0
+
+    def test_gitignored_python_excluded_from_patterns(self, tmp_repo):
+        """Python files in gitignored dirs should not affect pattern detection."""
+        import subprocess
+
+        # Add a venv with camelCase Python code that would skew naming detection
+        venv = tmp_repo / "my-venv" / "lib" / "pkg"
+        venv.mkdir(parents=True)
+        (venv / "badStyle.py").write_text(
+            "def camelCaseFunc():\n    pass\n\n"
+            "def anotherCamel():\n    pass\n\n"
+            "def yetAnother():\n    pass\n"
+        )
+
+        # Gitignore the venv
+        (tmp_repo / ".gitignore").write_text("my-venv/\n")
+        subprocess.run(["git", "add", ".gitignore"], cwd=tmp_repo, capture_output=True, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "chore: add gitignore"],
+            cwd=tmp_repo,
+            capture_output=True,
+            check=True,
+        )
+
+        detector = PatternDetector(repo_path=tmp_repo)
+        result = detector.analyze()
+
+        # camelCase should NOT appear as a detected convention
+        camel_conventions = [c for c in result.naming_conventions if c.pattern == "camelCase"]
+        assert not camel_conventions, "Gitignored camelCase code should not affect detection"
+
+    def test_gitignored_dirs_excluded_from_architecture(self, tmp_repo):
+        """Gitignored pyproject.toml files should not trigger monorepo detection."""
+        import subprocess
+
+        # Add a gitignored dir with its own pyproject.toml
+        ignored_pkg = tmp_repo / "vendor" / "somepkg"
+        ignored_pkg.mkdir(parents=True)
+        (ignored_pkg / "pyproject.toml").write_text('[project]\nname = "vendor"\n')
+
+        (tmp_repo / ".gitignore").write_text("vendor/\n")
+        subprocess.run(["git", "add", ".gitignore"], cwd=tmp_repo, capture_output=True, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "chore: add gitignore"],
+            cwd=tmp_repo,
+            capture_output=True,
+            check=True,
+        )
+
+        detector = PatternDetector(repo_path=tmp_repo)
+        result = detector.analyze()
+
+        assert "monorepo" not in result.architecture_patterns

--- a/tests/analyzers/test_pattern_detector.py
+++ b/tests/analyzers/test_pattern_detector.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import subprocess
+
 from codebase_archaeologist.analyzers.pattern_detector import PatternDetector
 
 
@@ -88,7 +90,6 @@ class TestPatternDetector:
 
     def test_gitignored_python_excluded_from_patterns(self, tmp_repo):
         """Python files in gitignored dirs should not affect pattern detection."""
-        import subprocess
 
         # Add a venv with camelCase Python code that would skew naming detection
         venv = tmp_repo / "my-venv" / "lib" / "pkg"
@@ -118,7 +119,6 @@ class TestPatternDetector:
 
     def test_gitignored_dirs_excluded_from_architecture(self, tmp_repo):
         """Gitignored pyproject.toml files should not trigger monorepo detection."""
-        import subprocess
 
         # Add a gitignored dir with its own pyproject.toml
         ignored_pkg = tmp_repo / "vendor" / "somepkg"


### PR DESCRIPTION
## Summary

- Use `git ls-files --cached --others --exclude-standard -z` as the source of truth for which files belong to a codebase
- Falls back to hardcoded exclude dirs (`_FALLBACK_EXCLUDE_DIRS`) for non-git repos
- Directory tree and architecture pattern detection now use the same git-aware filtering
- Fixes false positives caused by scanning venvs, node_modules, or other gitignored dirs with non-standard names

### Before (scanning .venv-ai/ on HealthReporting)
- Entry points: `dotenv/cli.py`, `dotenv/main.py` (third-party garbage)
- Architecture: layered, MVC, monorepo (false positives)
- Docstring coverage: 32% (diluted by venv code)

### After (git-aware)
- Entry points: `api/server.py`, `mcp/server.py` (correct)
- Architecture: layered (correct)
- Docstring coverage: 50% (real metric)

## Changes
- `analyzers/base.py` — new `_get_git_files()`, `_is_path_gitignored()`, git-aware `_collect_files()`
- `analyzers/code_structure.py` — `_build_directory_tree()` uses `_is_path_gitignored()`
- `analyzers/pattern_detector.py` — `_detect_architecture_patterns()` uses `_collect_files()` instead of raw rglob
- 4 new tests (100 total, all green)

## Test plan
- [x] 100 tests passing (96 existing + 4 new)
- [x] Verified on HealthReporting repo (229-test Python project with .venv-ai/)
- [x] Pre-commit hooks passing (gitleaks, ruff, formatting)
- [x] Claude code-reviewer: WARN → all findings fixed
- [x] Claude security-reviewer: WARN → all findings fixed

Generated with Claude Code